### PR TITLE
Allow for custom options to be passed as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ requestWithRetry('http://www.vimeo.com')
 
 #### autoRetry(fn, options) ⇒ <code>function</code>
 Higher order function that makes any promise-returning-function
-retryable with a jittr'd exponential backoff.
+retryable with a jitter'd exponential backoff.
 
 | Param | Type | Description |
 | --- | --- | --- |
 | fn | <code>function</code> | Function to be made retryable. |
 | options | <code>Object</code> | Configuration. |
+| options.backoffBase | <code>Number</code> | Base interval for backoff wait time (in ms). |
+| options.logRetries | <code>Boolen</code> | Log retry attempts to the console. |
 | options.maxRetries | <code>Number</code> | Total number of retries. |
 | options.retryCount | <code>Number</code> | Current retry count. |
-| options.backoffBase | <code>Number</code> | Base interval for backoff wait time (in ms). |
 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 
-# auto-retry: automatically retry any function
+# auto-retry
 
 [![npm package](https://nodei.co/npm/auto-retry.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/auto-retry/)
 
 [![Build Status](https://travis-ci.org/bhstahl/auto-retry.svg?branch=master)](https://travis-ci.org/bhstahl/auto-retry)
 [![Coverage Status](https://coveralls.io/repos/github/bhstahl/auto-retry/badge.svg?branch=master)](https://coveralls.io/github/bhstahl/auto-retry?branch=master)
 
+## Description
+
 Automatically add exponential retry abilities to any function that returns a promise, only rejecting after the retries fail.
+
+## Installation
+
+```sh
+$ npm install auto-retry
+```
+
+## Example
 
 ```js
 const requestPromise = require('request-promise');
 const autoRetry = require('auto-retry');
 
-// Construct a new function with automatic retry capabilites
-const requestWithRetry = autoRetry(requestPromise, 3);
+// Construct a new function with automatic retry capabilities
+const requestWithRetry = autoRetry(requestPromise);
 
 // Make a request
 requestWithRetry('http://www.vimeo.com')
@@ -23,4 +33,28 @@ requestWithRetry('http://www.vimeo.com')
     .catch((error) => {
         // Only called after 3 failed attempts
     });
+```
+
+## Documentation
+
+#### autoRetry(fn, options) ⇒ <code>function</code>
+Higher order function that makes any promise-returning-function
+retryable with a jittr'd exponential backoff.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | <code>function</code> | Function to be made retryable. |
+| options | <code>Object</code> | Configuration. |
+| options.maxRetries | <code>Number</code> | Total number of retries. |
+| options.retryCount | <code>Number</code> | Current retry count. |
+| options.backoffBase | <code>Number</code> | Base interval for backoff wait time (in ms). |
+
+
+```js
+// Construct a new function to only retry once
+const requestWithRetry = autoRetry(requestPromise, { maxRetries: 1 });
+
+
+// Set a minimum backoff interval to 2 seconds
+const requestWithRetry = autoRetry(requestPromise, { backoffBase: 2000 });
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,26 @@
-
 /**
  * Higher order function that makes any promise-returning-function
  * retryable with a jittr'd exponential backoff.
  *
- * @param  {Function} fn            Function to be made retryable.
- * @param  {Number}   maxRetries    Total number of retries.
- * @param  {Number}   retryCount    Current retry count.
+ * @param  {Function} fn                    Function to be made retryable.
+ * @param  {Object}   options               Configuration.
+ * @param  {Number}   options.maxRetries    Total number of retries.
+ * @param  {Number}   options.retryCount    Current retry count.
  * @return {Function}
  */
-export default function retryFunctionOnReject(fn, maxRetries = 2, retryCount = 0) {
+export default function retryFunctionOnReject(fn, options) {
+    options = Object.assign({ maxRetries: 2, retryCount: 0 }, options);
     return (...args) => {
         return new Promise((resolve, reject) => {
             fn(...args)
             .then(resolve)
             .catch((error) => {
-                const count = retryCount + 1;
-                if (count > maxRetries) {
+                options.retryCount++;
+                if (options.retryCount > options.maxRetries) {
                     return reject(error);
                 }
-                const delay = (Math.pow(2, count) * 1000) + (Math.round(Math.random() * 1000));
-                const nextFn = retryFunctionOnReject(fn, maxRetries, count);
+                const delay = (Math.pow(2, options.retryCount) * 1000) + (Math.round(Math.random() * 1000));
+                const nextFn = retryFunctionOnReject(fn, options);
                 return setTimeout(() => {
                     nextFn(...args).then(resolve).catch(reject);
                 }, delay);

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,11 @@
  * @param  {Object}   options               Configuration.
  * @param  {Number}   options.maxRetries    Total number of retries.
  * @param  {Number}   options.retryCount    Current retry count.
+ * @param  {Number}   options.backoffBase   Base interval for backoff wait time (in ms).
  * @return {Function}
  */
 export default function retryFunctionOnReject(fn, options) {
-    options = Object.assign({ maxRetries: 2, retryCount: 0 }, options);
+    options = Object.assign({ maxRetries: 2, retryCount: 0, backoffBase: 1000 }, options);
     return (...args) => {
         return new Promise((resolve, reject) => {
             fn(...args)
@@ -19,7 +20,7 @@ export default function retryFunctionOnReject(fn, options) {
                 if (options.retryCount > options.maxRetries) {
                     return reject(error);
                 }
-                const delay = (Math.pow(2, options.retryCount) * 1000) + (Math.round(Math.random() * 1000));
+                const delay = (Math.pow(2, options.retryCount) * options.backoffBase) + (Math.round(Math.random() * options.backoffBase));
                 const nextFn = retryFunctionOnReject(fn, options);
                 return setTimeout(() => {
                     nextFn(...args).then(resolve).catch(reject);

--- a/test/index.js
+++ b/test/index.js
@@ -57,7 +57,7 @@ test('autoRetry responds to custom options', (t) => {
         return Promise.reject('failed');
     };
 
-    const options = { maxRetries: 1 };
+    const options = { maxRetries: 1, logRetries: true, backoffBase: 50 };
     const rejectedFunctionWithRetry = autoRetry(rejectedFunction, options);
     return rejectedFunctionWithRetry().catch((result) => {
         t.true(result === 'failed');

--- a/test/index.js
+++ b/test/index.js
@@ -1,20 +1,6 @@
 import test from 'ava';
 import autoRetry from '../src/index';
 
-test('autoRetry retries on rejection', (t) => {
-    let timesFunctionWasCalled = 0;
-    const rejectedFunction = () => {
-        timesFunctionWasCalled++;
-        return Promise.reject('failed');
-    };
-
-    const rejectedFunctionWithRetry = autoRetry(rejectedFunction, 1);
-    return rejectedFunctionWithRetry().catch((result) => {
-        t.true(result === 'failed');
-        t.true(timesFunctionWasCalled === 2);
-    });
-});
-
 test('autoRetry resolves successfully', (t) => {
     let timesFunctionWasCalled = 0;
     const resolvedFunction = () => {
@@ -22,7 +8,7 @@ test('autoRetry resolves successfully', (t) => {
         return Promise.resolve('success');
     };
 
-    const resolvedFunctionWithRetry = autoRetry(resolvedFunction, 1);
+    const resolvedFunctionWithRetry = autoRetry(resolvedFunction);
     return resolvedFunctionWithRetry().then((result) => {
         t.true(result === 'success');
         t.true(timesFunctionWasCalled === 1);
@@ -30,14 +16,32 @@ test('autoRetry resolves successfully', (t) => {
     });
 });
 
-test('autoRetry responds to default parameters', (t) => {
+test('autoRetry resolves successfully after rejection', (t) => {
     let timesFunctionWasCalled = 0;
-    const rejectedFunction = () => {
+    const resolvedFunction = () => {
+        timesFunctionWasCalled++;
+        if (timesFunctionWasCalled < 2) {
+            return Promise.reject('failed');
+        }
+        return Promise.resolve('success');
+    };
+
+    const resolvedFunctionWithRetry = autoRetry(resolvedFunction);
+    return resolvedFunctionWithRetry().then((result) => {
+        t.true(result === 'success');
+        t.true(timesFunctionWasCalled === 2);
+        return;
+    }).catch(console.warn);
+});
+
+test('autoRetry rejects eventually', (t) => {
+    let timesFunctionWasCalled = 0;
+    const resolvedFunction = () => {
         timesFunctionWasCalled++;
         return Promise.reject('failed');
     };
 
-    const resolvedFunctionWithRetry = autoRetry(rejectedFunction);
+    const resolvedFunctionWithRetry = autoRetry(resolvedFunction);
     return resolvedFunctionWithRetry().catch((result) => {
         t.true(result === 'failed');
         t.true(timesFunctionWasCalled === 3);
@@ -45,14 +49,16 @@ test('autoRetry responds to default parameters', (t) => {
     });
 });
 
-test('autoRetry responds to custom parmeters', (t) => {
+
+test('autoRetry responds to custom options', (t) => {
     let timesFunctionWasCalled = 0;
     const rejectedFunction = () => {
         timesFunctionWasCalled++;
         return Promise.reject('failed');
     };
 
-    const rejectedFunctionWithRetry = autoRetry(rejectedFunction, 3, 2);
+    const options = { maxRetries: 1 };
+    const rejectedFunctionWithRetry = autoRetry(rejectedFunction, options);
     return rejectedFunctionWithRetry().catch((result) => {
         t.true(result === 'failed');
         t.true(timesFunctionWasCalled === 2);


### PR DESCRIPTION
To prepare for a 1.0.0 release, configuration should be passed to the function as an object. This provides a more descriptive API, and allows future releases to add more configuration without introducing breaking changes.

Also added the ability to configure the backoff interval base in miliseconds