### PR TITLE
Remove `module` and `es:next` main fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "1.0.1",
   "description": "Exponentially retry any promise returning function when it fails, automatically",
   "main": "src/index.transpiled.js",
-  "module": "src/index.js",
-  "jsnext:main": "src/index.js",
   "typings": "index.d.ts",
   "files": [
     "LICENSE",


### PR DESCRIPTION
This module breaks UglifyJS in a webpack build with `babel-loader` configured to ignore `node_modules`, which is usually the case for most builds. Unless there's a use case for these fields, I think we can drop them!
